### PR TITLE
Reverted Skybox mat (didn't realise it changed)

### DIFF
--- a/Team Rhythm Project 1/Assets/Models/Textures/skybox.mat
+++ b/Team Rhythm Project 1/Assets/Models/Textures/skybox.mat
@@ -79,7 +79,7 @@ Material:
     - _Cull: 2
     - _Cutoff: 0.5
     - _DstBlend: 0
-    - _Exposure: 0.899326
+    - _Exposure: 0.721333
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1


### PR DESCRIPTION
exposure back to 0.721333